### PR TITLE
Fix transcript duplication

### DIFF
--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -29,3 +29,16 @@ def test_rollover_dst(tmp_path):
     path_before = polling.transcript_path(before)
     path_after = polling.transcript_path(after)
     assert path_before != path_after
+
+
+def test_deduplicate_transcript(tmp_path):
+    file_path = tmp_path / "test.md"
+    file_path.write_text(
+        "# transcript for 2024-05-04\n\n"
+        "## 10:00:00 -- title\n\nhello\n\n"
+        "## 11:00:00 -- title\n\nhello\n\n"
+    )
+    polling.deduplicate_transcript(str(file_path))
+    content = file_path.read_text()
+    assert content.count("hello") == 1
+


### PR DESCRIPTION
## Summary
- add `deduplicate_transcript` helper
- use it at startup and on day rollover
- only append new lifelog content once
- test the new deduplication helper

## Testing
- `python -m py_compile polling.py tests/test_polling.py`
- `pytest -q` *(fails: `pytest: command not found`)*