### PR TITLE
Adjust polling to fetch text chunks

### DIFF
--- a/tests/test_polling.py
+++ b/tests/test_polling.py
@@ -1,7 +1,5 @@
 import os
-import tempfile
 from datetime import datetime
-from unittest import mock
 
 import pytest
 


### PR DESCRIPTION
## Summary
- simplify imports in polling and tests
- pull text chunks instead of full markdown for lifelogs
- prefer `text` field when writing to transcripts

## Testing
- `python -m py_compile polling.py tests/test_polling.py`
- *(flake8/pytest unavailable: installation failed)*